### PR TITLE
Fix app gradually increasing memory usage while running

### DIFF
--- a/src-tauri/src/watch.rs
+++ b/src-tauri/src/watch.rs
@@ -56,6 +56,7 @@ pub fn watch(window: Window, file_path: String) {
                 .watcher()
                 .watch(Path::new(&file_path), RecursiveMode::Recursive)
                 .expect("Error while watching file");
+            thread::sleep(Duration::from_millis(300));
         });
 
         let (sender, _) = channel();


### PR DESCRIPTION
Closes #9.

As it turns out, all that was needed to fix this difficult looking issue was adding this line:

```rust
thread::sleep(Duration::from_millis(300));
```
